### PR TITLE
Improve `git issue help` output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: bash
-script: ./test.sh
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ install:
 sync-docs:
 	./sync-docs.sh
 
+test:
+	./test.sh
+
 uninstall:
 	rm -f $(DESTDIR)$(BINPREFIX)/git-issue
 	rm -f $(DESTDIR)$(MANPREFIX)/git-issue.
@@ -24,4 +27,4 @@ uninstall:
 
 clean:
 
-.PHONY: default clean install uninstall sync-docs
+.PHONY: default clean install uninstall sync-docs test

--- a/README.md
+++ b/README.md
@@ -69,14 +69,15 @@ its operation, and (please) update this file.
 ## Use
 You use _git issue_ with the following sub-commands.
 
+### start an issue repository
+* `git issue clone`: Clone the specified remote repository.
 * `git issue init`: Create a new issues repository in the current directory.
   The `-e` option uses an existing Git project repository.
-* `git issue clone`: Clone the specified remote repository.
-* `git issue new`: Create a new open issue with the specified summary.
-* `git issue list`: List the issues with the specified tag.
-  By default this lists issues that are tagged as `open`.
+### work with an issue
+* `git issue new`: Create a new open issue (with optional `-s` summary).
 * `git issue show`: Show specified issue (and its comments with `-c`).
 * `git issue comment`: Add an issue comment.
+* `git issue edit`: Edit the specified issue's summary (not yet implemented)
 * `git issue tag`: Add (or remove with `-r`) a tag.
 * `git issue assign`: Assign (or reassign) an issue to a person.
   The person is specified with his/her email address.
@@ -84,12 +85,16 @@ You use _git issue_ with the following sub-commands.
   uniquely identifies an existing assignee or committer.
 * `git issue attach`: Attach (or remove with `-r`) a file to an issue.
 * `git issue watcher`: Add (or remove with `-r`) an issue watcher.
-* `git issue close`: Remove the `open` tag from the issue, marking it as closed.
-* `git issue edit`: Edit the specified issue's summary or comment.
-* `git issue help`: Display help information about git issue.
-* `git issue log`: Output a log of changes made
+* `git issue close`: Remove the `open` tag, add the closed tag
+### show multiple issues
+* `git issue list`: List all issues (or just those with a given tag)
+  By default this lists issues that are tagged as `open`.
+### synchronize with remote repository
 * `git issue push`: Update remote repository with local changes.
 * `git issue pull`: Update local repository with remote changes.
+### help and debug
+* `git issue help`: Display help information about git issue.
+* `git issue log`: Output a log of changes made
 * `git issue git`: Run the specified Git command on the issues repository.
 
 Issues and comments are specified through the SHA hash associated with the

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ You use _git issue_ with the following sub-commands.
 * `git issue watcher`: Add (or remove with `-r`) an issue watcher.
 * `git issue close`: Remove the `open` tag, add the closed tag
 ### show multiple issues
-* `git issue list`: List all issues (or just those with a given tag)
-  By default this lists issues that are tagged as `open`.
+* `git issue list`: List open issues (or all with `-a`); supports tags
 ### synchronize with remote repository
 * `git issue push`: Update remote repository with local changes.
 * `git issue pull`: Update local repository with remote changes.

--- a/git-issue.1
+++ b/git-issue.1
@@ -140,8 +140,9 @@ to use to display long lists of results.
 
 .SH FILES
 .\" Auto-generated content from README.md; do not edit this section
-All data are stored under \fC.issues\fP. The directory contains the
-following elements.
+All data are stored under \fC.issues\fP, which should be placed under \fC.gitignore\fP,
+if it will coexist with another Git-based project.
+The directory contains the following elements.
 .IP "" 4
 A \fC.git\fP directory contains the Git data associated with the issues.
 .IP "" 4

--- a/git-issue.1
+++ b/git-issue.1
@@ -40,26 +40,20 @@ You use \fIgit issue\fP with the following sub-commands.
 
 .RE
 .PP
+\fBgit issue clone\fP
+.RS 4
+Clone the specified remote repository.
+.RE
+.PP
 \fBgit issue init\fP
 .RS 4
 Create a new issues repository in the current directory.
   The \fC-e\fP option uses an existing Git project repository.
 .RE
 .PP
-\fBgit issue clone\fP
-.RS 4
-Clone the specified remote repository.
-.RE
-.PP
 \fBgit issue new\fP
 .RS 4
-Create a new open issue with the specified summary.
-.RE
-.PP
-\fBgit issue list\fP
-.RS 4
-List the issues with the specified tag.
-  By default this lists issues that are tagged as \fCopen\fP.
+Create a new open issue (with optional \fC-s\fP summary).
 .RE
 .PP
 \fBgit issue show\fP
@@ -70,6 +64,11 @@ Show specified issue (and its comments with \fC-c\fP).
 \fBgit issue comment\fP
 .RS 4
 Add an issue comment.
+.RE
+.PP
+\fBgit issue edit\fP
+.RS 4
+Edit the specified issue's summary (not yet implemented)
 .RE
 .PP
 \fBgit issue tag\fP
@@ -97,22 +96,13 @@ Add (or remove with \fC-r\fP) an issue watcher.
 .PP
 \fBgit issue close\fP
 .RS 4
-Remove the \fCopen\fP tag from the issue, marking it as closed.
+Remove the \fCopen\fP tag, add the closed tag
 .RE
 .PP
-\fBgit issue edit\fP
+\fBgit issue list\fP
 .RS 4
-Edit the specified issue's summary or comment.
-.RE
-.PP
-\fBgit issue help\fP
-.RS 4
-Display help information about git issue.
-.RE
-.PP
-\fBgit issue log\fP
-.RS 4
-Output a log of changes made
+List all issues (or just those with a given tag)
+  By default this lists issues that are tagged as \fCopen\fP.
 .RE
 .PP
 \fBgit issue push\fP
@@ -123,6 +113,16 @@ Update remote repository with local changes.
 \fBgit issue pull\fP
 .RS 4
 Update local repository with remote changes.
+.RE
+.PP
+\fBgit issue help\fP
+.RS 4
+Display help information about git issue.
+.RE
+.PP
+\fBgit issue log\fP
+.RS 4
+Output a log of changes made
 .RE
 .PP
 \fBgit issue git\fP

--- a/git-issue.1
+++ b/git-issue.1
@@ -101,8 +101,7 @@ Remove the \fCopen\fP tag, add the closed tag
 .PP
 \fBgit issue list\fP
 .RS 4
-List all issues (or just those with a given tag)
-  By default this lists issues that are tagged as \fCopen\fP.
+List open issues (or all with \fC-a\fP); supports tags
 .RE
 .PP
 \fBgit issue push\fP

--- a/git-issue.sh
+++ b/git-issue.sh
@@ -577,24 +577,35 @@ sub_help()
   #
   cat <<\USAGE_EOF
 usage: git issue <command> [<args>]
-The following commands are available
-git issue init: Create a new issues repository in the current directory.
-git issue clone: Clone the specified remote repository.
-git issue new: Create a new open issue with the specified summary.
-git issue list: List the issues with the specified tag.
-git issue show: Show specified issue (and its comments with -c).
-git issue comment: Add an issue comment.
-git issue tag: Add (or remove with -r) a tag.
-git issue assign: Assign (or reassign) an issue to a person.
-git issue attach: Attach (or remove with -r) a file to an issue.
-git issue watcher: Add (or remove with -r) an issue watcher.
-git issue close: Remove the open tag from the issue, marking it as closed.
-git issue edit: Edit the specified issue's summary or comment.
-git issue help: Display help information about git issue.
-git issue log: Output a log of changes made
-git issue push: Update remote repository with local changes.
-git issue pull: Update local repository with remote changes.
-git issue git: Run the specified Git command on the issues repository.
+
+The following commands are available:
+
+start an issue repository
+   clone      Clone the specified remote repository
+   init       Create a new issues repository in the current directory
+
+work with an issue
+   new        Create a new open issue (with optional -s summary)
+   show       Show specified issue (and its comments with -c)
+   comment    Add an issue comment
+   edit       Edit the specified issue's summary (not yet implemented)
+   tag        Add (or remove with -r) a tag
+   assign     Assign (or reassign) an issue to a person
+   attach     Attach (or remove with -r) a file to an issue
+   watcher    Add (or remove with -r) an issue watcher
+   close      Remove the open tag, add the closed tag
+
+show multiple issues
+   list       List all issues (or just those with a given tag)
+
+synchronize with remote repository
+   push       Update remote repository with local changes
+   pull       Update local repository with remote changes
+
+help and debug
+   help       Display help information about git issue
+   log        Output a log of changes made
+   git        Run the specified Git command on the issues repository
 USAGE_EOF
 }
 

--- a/git-issue.sh
+++ b/git-issue.sh
@@ -596,7 +596,7 @@ work with an issue
    close      Remove the open tag, add the closed tag
 
 show multiple issues
-   list       List all issues (or just those with a given tag)
+   list       List open issues (or all with -a); supports tags
 
 synchronize with remote repository
    push       Update remote repository with local changes

--- a/sync-docs.sh
+++ b/sync-docs.sh
@@ -25,11 +25,26 @@ MAN_PAGE=git-issue.1
 
 # Update usage information in the script based on README.md
 {
-  sed -n '1,/^The following commands are available/p' $SCRIPT_NAME
-  sed -n '/^\* `git issue init`/,/^\* `git issue git`/ {
-    /^\* /!d
+  sed -n '1,/^The following commands are available:/p' $SCRIPT_NAME
+  # Keep lines from `### start ` to `git issue git`
+  sed -n '/^### start/,/^\* `git issue git`/ {
+    # Only keep listed commands or subheaders
+    /^\* \|^### /!d
+    # Format headers by eliminating all preceding space
+    s/^### \(.*\)/\n\1/g
+    # Remove repetitive git issue
+    s/git issue //g
+    # Remove code markup
     s/`//g
-    s/^\* //
+    # Remove fullstops
+    s/\.//g
+    # Format commands, depending on length
+    s/^\* \([^:]\{3\}\): /   \1        /g
+    s/^\* \([^:]\{4\}\): /   \1       /g
+    s/^\* \([^:]\{5\}\): /   \1      /g
+    s/^\* \([^:]\{6\}\): /   \1     /g
+    s/^\* \([^:]\{7\}\): /   \1    /g
+
     p
   }' README.md
   sed -n '/^USAGE_EOF/,$p' $SCRIPT_NAME
@@ -55,6 +70,7 @@ replace_section()
       $command"'
       # Remove section titles
       /^## /d
+      /^###/d
       # Set code text with Courier (twice per line)
       s/`/\\fC/;s/`/\\fP/
       s/`/\\fC/;s/`/\\fP/

--- a/test.sh
+++ b/test.sh
@@ -111,6 +111,18 @@ ntest=0
 gi=../git-issue.sh
 gi_re=$(echo $gi | sed 's/[^0-9A-Za-z]/\\&/g')
 rm -rf testdir
+
+start
+GenFiles="git-issue.sh git-issue.1"
+make sync-docs
+Status=$(git status --porcelain -- $GenFiles)
+if [ -z "$Status" ]; then
+    ok "make sync-docs left $GenFiles as committed"
+else
+    fail "make sync-docs changed $GenFiles"
+    git checkout -- $GenFiles
+fi
+
 mkdir testdir
 cd testdir
 


### PR DESCRIPTION
Make it look like git's own help:

* Remove repetitive `git issue`
* Remove repetitive colons
* Remove repetitive fullstops
* Align commands and explanations like `git help`
* Group commands logically and add headers
* Rephrase some help texts for clarity