### PR TITLE
Implement git issue edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You use _git issue_ with the following sub-commands.
 * `git issue new`: Create a new open issue (with optional `-s` summary).
 * `git issue show`: Show specified issue (and its comments with `-c`).
 * `git issue comment`: Add an issue comment.
-* `git issue edit`: Edit the specified issue's summary (not yet implemented)
+* `git issue edit`: Edit the specified issue's description
 * `git issue tag`: Add (or remove with `-r`) a tag.
 * `git issue assign`: Assign (or reassign) an issue to a person.
   The person is specified with his/her email address.

--- a/git-issue.1
+++ b/git-issue.1
@@ -68,7 +68,7 @@ Add an issue comment.
 .PP
 \fBgit issue edit\fP
 .RS 4
-Edit the specified issue's summary (not yet implemented)
+Edit the specified issue's description
 .RE
 .PP
 \fBgit issue tag\fP

--- a/git-issue.sh
+++ b/git-issue.sh
@@ -102,9 +102,18 @@ trans_abort()
 # commit <summary> <message>
 commit()
 {
-  git commit --allow-empty -q -m "$1
+    commit_summary=$1
+    shift
+    commit_message=$1
+    shift
+    if [ "$1" ]; then
+        commit_date=$1
+    else
+        commit_date=$(date -R)
+    fi
+  git commit --allow-empty -q --date="$commit_date" -m "$commit_summary
 
-$2" || trans_abort
+$commit_message" || trans_abort
 }
 
 # Allow the user to edit the specified file
@@ -224,7 +233,8 @@ sub_new()
   shift $(($OPTIND - 1));
 
   trans_start
-  commit 'gi: Add issue' 'gi new mark'
+  date=$(date -R)
+  commit 'gi: Add issue' 'gi new mark' "$date"
   sha=$(git rev-parse HEAD)
   path=$(issue_path_full $sha)
   mkdir -p $path || trans_abort
@@ -236,7 +246,7 @@ sub_new()
     edit $path/description || trans_abort
   fi
   git add $path/description $path/tags || trans_abort
-  commit 'gi: Add issue description' "gi new description $sha"
+  commit 'gi: Add issue description' "gi new description $sha" "$date"
   echo "Added issue $(short_sha $sha)"
 }
 

--- a/git-issue.sh
+++ b/git-issue.sh
@@ -124,10 +124,18 @@ edit()
   local file
 
   file="$1"
-  ${VISUAL:-vi} "$file" || return 1
-  grep -v '^#' "$file" >"$file.new"
+  touch "$file"
+  cp "$file" "$file.new"
+  echo "Opening editor..."
+  ${VISUAL:-vi} "$file.new" || return 1
+  sed -i '/^#/d' "$file.new"
   if [ $(grep -c . "$file.new") -eq 0 ] ; then
     echo 'Empty file' 1>&2
+    rm -f "$file.new"
+    return 1
+  fi
+  if [ $(diff "$file" "$file.new" > /dev/null 2>&1) ]; then
+    echo 'File was not changed' 1>&2
     rm -f "$file.new"
     return 1
   fi

--- a/test.sh
+++ b/test.sh
@@ -108,9 +108,8 @@ start()
 
 echo 'TAP version 13'
 ntest=0
-gi=../git-issue.sh
+gi=$(pwd)/git-issue.sh
 gi_re=$(echo $gi | sed 's/[^0-9A-Za-z]/\\&/g')
-rm -rf testdir
 
 start
 GenFiles="git-issue.sh git-issue.1"
@@ -122,6 +121,10 @@ else
     fail "make sync-docs changed $GenFiles"
     git checkout -- $GenFiles
 fi
+
+TopDir=$(mktemp -d)
+echo "Test artifacts saved in $TopDir"
+cd $TopDir
 
 mkdir testdir
 cd testdir
@@ -227,5 +230,3 @@ try $gi pull
 $gi git reset --hard >/dev/null # Required, because we pushed to a non-bare repo
 start ; $gi show $issue | try_grep '^Tags:.*cloned'
 
-cd ..
-rm -rf testdir testdir2

--- a/test.sh
+++ b/test.sh
@@ -40,6 +40,7 @@ ok()
 
 fail()
 {
+  failed=1
   message fail $*
 }
 
@@ -107,6 +108,7 @@ start()
 }
 
 echo 'TAP version 13'
+failed=0
 ntest=0
 gi=$(pwd)/git-issue.sh
 gi_re=$(echo $gi | sed 's/[^0-9A-Za-z]/\\&/g')
@@ -230,3 +232,10 @@ try $gi pull
 $gi git reset --hard >/dev/null # Required, because we pushed to a non-bare repo
 start ; $gi show $issue | try_grep '^Tags:.*cloned'
 
+if [ $failed -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi

--- a/test.sh
+++ b/test.sh
@@ -153,7 +153,6 @@ Second issue
 Line in description
 EOF
 try $gi new
-export VISUAL=
 
 issue=$($gi list | awk '/Second issue/{print $1}')
 
@@ -163,6 +162,23 @@ start ; $gi show $issue | try_grep 'Line in description'
 start ; $gi show $issue | try_grep '^Author:'
 start ; $gi show $issue | try_grep '^Tags:[ 	]*open'
 ntry $gi show xyzzy
+
+# Edit
+
+# Unmodified issue should fail
+ntry $gi edit $issue
+
+cat <<EOF >issue-desc
+Second issue
+
+Modified line in description
+EOF
+try $gi edit $issue
+start ; $gi show $issue | try_grep 'Second issue'
+start ; $gi show $issue | try_grep 'Modified line in description'
+start ; $gi show $issue | try_ngrep 'Line in description'
+
+export VISUAL=
 
 # Comment
 start
@@ -225,7 +241,7 @@ start ; $gi show $issue | try_grep '^Watchers:.*alice@example.com'
 start ; $gi show $issue | try_grep '^Tags:.*feature'
 start ; $gi show $issue | try_grep '^Assigned-to:[ 	]joe@example.com'
 start ; $gi show $issue | try_grep 'Second issue'
-start ; $gi show $issue | try_grep 'Line in description'
+start ; $gi show $issue | try_grep 'Modified line in description'
 start ; $gi show $issue | try_grep '^Author:'
 start ; $gi show $issue | try_grep '^Tags:.*closed'
 

--- a/test.sh
+++ b/test.sh
@@ -141,13 +141,18 @@ try $gi new -s 'First-issue'
 start ; $gi list | try_grep 'First-issue'
 
 # New with editor
-start
+export VISUAL='mv ../issue-desc '
+
+# Empty summary/description should fail
+touch issue-desc
+ntry $gi new
+
 cat <<EOF >issue-desc
 Second issue
 
 Line in description
 EOF
-export VISUAL='mv ../issue-desc '; try $gi new
+try $gi new
 export VISUAL=
 
 issue=$($gi list | awk '/Second issue/{print $1}')


### PR DESCRIPTION
First and unrelated, this PR includes the following general improvements:
* Use a temp directory to preserve test artifacts after a test run (to ease debugging)
* Make the test script return 0 only when all tests are successful
* Add a test that checks whether `git issue new` fails if an empty file is given as description

Then it includes an implementation for `git issue edit`:
* The commit date/times of a new issue allocation and it's description creation are now made identical (to have an accurate edit history, based on the description file, which is created separately after the issue is opened and a SHA is assigned)
* The edit function fails when the target file is unchanged (to be able to detect an aborted edit operation)
* The edit operation is added, including doc updates and tests

Feedback is very welcome!