### PR TITLE
Allow autocompletion of subcommand arguments after flags, too

### DIFF
--- a/gi-completion.sh
+++ b/gi-completion.sh
@@ -19,6 +19,7 @@
 #
 
 # Autocompletes the gi subcommand sequence.
+# Arguments: the current word
 _gi_autocomplete_subcommand()
 {
   local IFS=$'\n' command_regex="git issue\s([^:]*):.*"
@@ -33,11 +34,10 @@ _gi_autocomplete_subcommand()
 }
 
 # Autocompletes the gi subcommands' argument sequence.
+# Arguments: the subcommand, the current word
 _gi_autocomplete_subcommand_argument()
 {
-  local list_args subcommand=${COMP_WORDS[COMP_CWORD-1]}
-
-  case $subcommand in
+  case $1 in
     show | comment | tag | assign | attach | watcher)
       # list all issues
       list_args="-a"
@@ -55,7 +55,7 @@ _gi_autocomplete_subcommand_argument()
 
   while read -r line; do
     desc=($(echo $line | sed 's/ /\n/'))
-    cmd=$(compgen -W "${desc[0]}" -- "$1")
+    cmd=$(compgen -W "${desc[0]}" -- "$2")
 
     if [ -n "$cmd" ]; then
       # Store the matching issues along with their description
@@ -94,7 +94,8 @@ _gi_autocomplete()
     if [ "$COMP_CWORD" -eq "$baseidx" ]; then
         _gi_autocomplete_subcommand $word
     else
-        _gi_autocomplete_subcommand_argument $word
+        local subcmd=${COMP_WORDS[$baseidx]}
+        _gi_autocomplete_subcommand_argument $subcmd $word
     fi 
   else
     __git_wrap__gitk_main


### PR DESCRIPTION
Until now when using flags like the ``-c`` flag of the ``show`` subcommand, autocompletion of the hashes did not work.

By not assuming that the previous word was the subcommand in ``_gi_autocomplete_subcommand_argument``, but passing the subcommand as an argument instead, it works now.