### PR TITLE
allow autocompletion for the milestone subcommand

### DIFF
--- a/gi-completion.sh
+++ b/gi-completion.sh
@@ -42,7 +42,7 @@ _gi_autocomplete_subcommand_argument()
       # list all issues
       list_args="-a"
       ;;
-    edit | close)
+    edit | close | milestone)
       # list only open issues
       list_args=""
       ;;


### PR DESCRIPTION
autocompleting open issues should work for the ``milestone`` subcommand, too.