### PR TITLE
fix autocompletion of subcommands

### DIFF
--- a/gi-completion.sh
+++ b/gi-completion.sh
@@ -21,7 +21,7 @@
 # Autocompletes the gi subcommand sequence.
 _gi_autocomplete_subcommand()
 {
-  local IFS=$'\n' command_regex="git issue\s([^:]*):.*"
+  local IFS=$'\n' command_regex="^\s{3}([a-z]+)\s.*"
 
   # parse help information for sub commands
   while read -r line; do


### PR DESCRIPTION
The old reglular expression for autocompleting subcommands did not fit the current help output.