### PR TITLE
git-for-windows docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ by adding the following to your .bashrc.
 source ${REPO_PATH}/gi-completion.sh
 ```
 
+### [Git for Windows](https://gitforwindows.org/)
+If you are running Git for Windows and do not have `make` available,
+first note that the default installation location of `/usr/local`
+cannot be used as it returns "permission denied". One alternative
+includes `PREFIX=$HOME`, assuming that Windows is configured with the
+appropriate environment variable; regardless, you must determine this
+destination and determine that you have permissions to create that
+path.
+
+If `install_gfw.sh` does not exist, then you can first create it with
+
+```
+sh sync-docs.sh
+```
+
+Using the determined installation destination for `PREFIX`, install
+using
+
+```
+PREFIX=... sh install_gfw.sh
+```
+
 ### Backward compatibility with the gi command
 For backward compatibility you can also use the original _gi_ command,
 by copying `gi.sh` to someplace in your path.

--- a/sync-docs.sh
+++ b/sync-docs.sh
@@ -31,6 +31,19 @@
 SCRIPT_NAME=git-issue.sh
 MAN_PAGE=git-issue.1
 
+sed -n \
+    -E '{ 1,/^SYSCONFDIR/p; /^install:/,/^(\S|\s*$)/p }' Makefile | \
+  sed -E '{
+    /^install:/d ;
+    # remove Makefile leading no-echo @
+    s/^\s*@?// ;
+    # convert Makefile ?= conditional assignment to bash :-
+    s/^([^? ]+)\s*\?=\s*(.*)$/\1=${\1:-\2}/g ;
+    # convert $(VAR) to ${VAR}
+    s/\$\(([^)]+)\)/${\1}/g
+  }' > install_gfw.sh
+chmod +x install_gfw.sh
+
 # Update usage information in the script based on README.md
 {
   sed -n '1,/^The following commands are available:/p' $SCRIPT_NAME

--- a/sync-docs.sh
+++ b/sync-docs.sh
@@ -32,9 +32,8 @@ SCRIPT_NAME=git-issue.sh
 MAN_PAGE=git-issue.1
 
 sed -n \
-    -E '{ 1,/^SYSCONFDIR/p; /^install:/,/^(\S|\s*$)/p }' Makefile | \
+    -E '1,/^SYSCONFDIR/p; /^install:/,/^\S/ { /^\S/d; p; }' Makefile | \
   sed -E '{
-    /^install:/d ;
     # remove Makefile leading no-echo @
     s/^\s*@?// ;
     # convert Makefile ?= conditional assignment to bash :-


### PR DESCRIPTION
Documentation and script to create an installation script for git-bash (within git-for-windows), as a suggestion for #57.

This leverages on the variables and `install:` section of the existing `Makefile`, so it should update if/when the package itself changes.

I've *not* included the `install_gfw.sh` file for now, since I'm assuming you'd prefer it to not be the default for all users. However, it's rather small and can otherwise be ignored (or used for that matter). The script it creates is currently:

```bash
PREFIX=${PREFIX:-/usr/local}
BINPREFIX=${BINPREFIX:-"${PREFIX}/bin"}
LIBPREFIX=${LIBPREFIX:-"${PREFIX}/lib"}
MANPREFIX=${MANPREFIX:-"${PREFIX}/share/man/man1"}
SYSCONFDIR=${SYSCONFDIR:-${PREFIX}/etc}
mkdir -p ${DESTDIR}${MANPREFIX}
mkdir -p ${DESTDIR}${BINPREFIX}
mkdir -p ${DESTDIR}${LIBPREFIX}/git-issue
install git-issue.sh ${DESTDIR}${BINPREFIX}/git-issue
install lib/git-issue/import-export.sh ${DESTDIR}${LIBPREFIX}/git-issue/import-export.sh
install -m 644 git-issue.1 ${DESTDIR}${MANPREFIX}/
mkdir -p ${DESTDIR}${SYSCONFDIR}/bash_completion.d
install -m 644 gi-completion.sh ${DESTDIR}${SYSCONFDIR}/bash_completion.d/git-issue
```

This script has a few caveats/disclaimers:

- even though it does not start with the hash-bang header line, git-bash will still work, so the following (on GfW) both work:

    ```bash
    PREFIX=/some/path sh install_gfw.sh
    PREFIX=/some/path ./install-gfw.sh
    ```

- in GfW, the default prefix of `/usr/local` **will not work**, due to directory virtual mounts; I mention this in the docs, but it might be a commonly (perhaps frequently) asked question to the maintainer(s); we can easily define an alternate location to override the current default just in this installation file

- in GfW, `SYSCONFDIR` *is already defined* (or at least it is on mine) to `/etc`; as long as the user installs with `./install_gfw.sh` or `sh install_gfw.sh`, then this envvar is not inherited and the bash-completion script will be installed in `${PREFIX}/etc`; if, however, they decide to go with `. install_gfw.sh` (using `.` for `source`, not suggested in the docs), then they will receive an error

    ```
    mkdir: cannot create directory ‘/etc/bash_completion.d’: Permission denied
    ```

    The fix to this error is to define `SYSCONFDIR` (and/or `DESTDIR`). Or to not use `source` or `.`.

- this script can be run repeatedly, it does not fail or behave differently if the target directories and/or files already exist

General notes:

- I think the logic for converting make's conditional variable assignment (`?=`) is applied generally-enough to bash's (`:-`), but I'm sure it's possible to engineer incompatible make recipes. If you complicate your `Makefile` preamble, this script might no longer work.

- Similarly, it finds all installation-related code by finding the literal `install:` block and stops parsing when it finds the next line with a non-space in the first character. This means an inadvertent comment will be problematic:

    ```make
    install:
    	@mkdir -p $(DESTDIR)$(MANPREFIX)
    # something here
    	@mkdir -p $(DESTDIR)$(BINPREFIX)
    ```

    This would cause the second `mkdir` to be missed. (I don't know that this is legal for make, to be honest, just thought I'd state the parsing assumption.) This current method appears to handle blank lines and *indented* comments.

- On my system, this passes all tests except test 1, which fails due to CRLF issues. Also, tests 1 and 77 warn about the same line-ending problem, which I believe is safe to ignore:

    ```
    warning: LF will be replaced by CRLF in ...
    The file will have its original line endings in your working directory
    ```

    (I believe that the preferable config in windows is `core.autocrlf = true`, I might be wrong.)