### PR TITLE
library search: Swap precedence of /usr{/local,}/lib

### DIFF
--- a/git-issue.sh
+++ b/git-issue.sh
@@ -36,7 +36,7 @@ IFS=:
 # Set library path
 # shellcheck disable=SC2086
 # Rationale: Word splitting not an issue
-LIB_PATH="$(dirname $0)/../lib:$LD_LIBRARY_PATH:/usr/lib:/usr/local/lib"
+LIB_PATH="$(dirname $0)/../lib:$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib"
 if [ "x$GIT_ISSUE_LIB_PATH" != x ] ; then
   LIB_PATH="$GIT_ISSUE_LIB_PATH"
 fi


### PR DESCRIPTION
It is customary for /usr/local to contain software installed by the
local system administrator/owner and for that to override the same
software if provided at a system-wide level (e.g. in /usr/lib)

This address one of the issues touched on in #61 but does not fix
the key issue (IMHO) which is that `make install PREFIX=$HOME`
does not result in a working `git issue` so not marking it as fixed
in these commits.