### PR TITLE
Invoke pager only if output exceeds terminal size.

### DIFF
--- a/git-issue.sh
+++ b/git-issue.sh
@@ -228,11 +228,12 @@ EOF
 		then
 			{
 				echo -n "$output"
-				cat
+				while read -r txt; do
+					echo "$txt"
+				done
 			} | ${PAGER:-more}
 		else
 			echo -n "$output"
-			cat
 		fi
 	else
 		${PAGER:-more}


### PR DESCRIPTION
This patch makes usage of git-issue with PAGER=less more pleasant (at least on my system, Debian Buster).  It is to work around the following issues with less when a small amount of text is piped into it:

1. The terminal window is unnecessarily cleared while the text is being presented.

2. When the pager is quit, none of the displayed text is still visible.

3. The Q key must be used to quit the pager, even though all the text is displayed in the terminal and there is no reason for the pager to stay active.

The default PAGER of "more" does not behave this way and these annoyances are arguably bugs in the less program, but I prefer less over more because it lets me page up and down through longer outputs.

The work-around I've employed is for git-issue to keep track of the amount of output it is generating and only invoke the PAGER when it exceeds the capacity of the terminal window.

For this patch to work, the user must have stty (of coreutils) installed.
