### PR TITLE
Fix gitlab export feature due to the grep header bug

### DIFF
--- a/lib/git-issue/import-export.sh
+++ b/lib/git-issue/import-export.sh
@@ -142,11 +142,11 @@ rest_api_send()
     trans_abort
   fi
 
-  if ! grep -q '^\(Status: 20[0-9]\|HTTP/[[:digit:]].[[:digit:]] 20[0-9] Created\|HTTP/[[:digit:]].[[:digit:]] 200 OK\)' "$prefix-header" ; then
-    echo 'GitHub API communication failure' 1>&2
+  if ! grep -q '^\(Status: 20[0-9]\|HTTP/[[:digit:]].[[:digit:]] 20[0-9] Created\|HTTP/[[:digit:]].[[:digit:]] 200 OK\|HTTP/[[:digit:]] 200\)' "$prefix-header" ; then
+    echo "$provider API communication failure" 1>&2
     echo "URL: $url" 1>&2
     echo "Data: $data" 1>&2
-    if grep -q '^\(Status: 4\|HTTP/[0-9].[0-9] 4\)' "$prefix-header" ; then
+    if grep -q '^\(Status: 4\|HTTP/[0-9].[0-9] 4\|HTTP/[0-9] 4\)' "$prefix-header" ; then
       jq -r '.message' "$prefix-body" 1>&2
     fi
     trans_abort


### PR DESCRIPTION
`git issue export gitlab {username} {reponame}` did not work as expected on Mac OSX due to the bug found in https://github.com/dspinellis/git-issue/issues/70#issuecomment-607022134

This PR fixes that.