### PR TITLE
Fix empty endpoint bug

### DIFF
--- a/lib/git-issue/import-export.sh
+++ b/lib/git-issue/import-export.sh
@@ -564,7 +564,7 @@ import_comments()
     trans_abort
   fi
 
-  while true ; do
+  while [ ! -z "$endpoint" ] ; do
     rest_api_get "$endpoint" comments "$provider"
 
     # For each comment in the comments-body file


### PR DESCRIPTION
https://github.com/dspinellis/git-issue/blob/master/lib/git-issue/import-export.sh#L627 could be an empty string, which makes https://github.com/dspinellis/git-issue/blob/master/lib/git-issue/import-export.sh#L911 this call to fail (because https://github.com/dspinellis/git-issue/blob/master/lib/git-issue/import-export.sh#L90-L94 this line fails)