### PR TITLE
Fix computation of 'lib' path when calling 'git-issue.sh' without installing

### DIFF
--- a/git-issue.sh
+++ b/git-issue.sh
@@ -36,7 +36,7 @@ IFS=:
 # Set library path
 # shellcheck disable=SC2086
 # Rationale: Word splitting not an issue
-LIB_PATH="$(dirname $0)/../lib:$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib"
+LIB_PATH="$(dirname $0)/lib:$(dirname $0)/../lib:$LD_LIBRARY_PATH:/usr/local/lib:/usr/lib"
 if [ "x$GIT_ISSUE_LIB_PATH" != x ] ; then
   LIB_PATH="$GIT_ISSUE_LIB_PATH"
 fi

--- a/test.sh
+++ b/test.sh
@@ -180,10 +180,6 @@ ntest=0
 gi=$(pwd)/git-issue.sh
 gi_re=$(echo "$gi" | sed 's/[^0-9A-Za-z]/\\&/g')
 
-# Setup GIT_ISSUE_LIB_PATH to allow pulling import-export.sh from lib
-GIT_ISSUE_LIB_PATH="$(pwd)/lib"
-export GIT_ISSUE_LIB_PATH
-
 start sync-docs
 GenFiles='git-issue.sh git-issue.1'
 if ! git diff --quiet HEAD ; then


### PR DESCRIPTION
The test script doesn't need to set GIT_ISSUE_LIB_PATH as this can be computed
from the location of the 'git-issue.sh' script.