### PR TITLE
Fix rest_next_page_url for page 2 and up.

### DIFF
--- a/lib/git-issue/import-export.sh
+++ b/lib/git-issue/import-export.sh
@@ -873,7 +873,7 @@ s/^[Ll]ink:.<\([^>]*\)>; rel="next".*/\1/p
 # If substitution worked branch to end of script
 t
 # Remove first element of the Link header and retry
-s/^[Ll]ink: <[^>]*>; rel="[^"]*", */[Ll]ink: /
+s/^[Ll]ink: <[^>]*>; rel="[^"]*", */Link: /
 t again
 ' "$1"-header
 }


### PR DESCRIPTION
The code before replaced the start of the link header with the literal
string "[Ll]ink". This changes it to the correct string "Link".