### PR TITLE
Lower case command arguments user and repo

### DIFF
--- a/lib/git-issue/import-export.sh
+++ b/lib/git-issue/import-export.sh
@@ -24,6 +24,11 @@ USAGE_export_EOF
   exit 2
 }
 
+convert_to_lower_case()
+{
+  echo "$1" | tr '[:upper:]' '[:lower:]'
+}
+
 # importsget: Return all mentions of SHA given in imports
 
 importsget()
@@ -202,8 +207,8 @@ create_issue()
   path=$(issue_path_part "$1") || exit
   isha=$(issue_sha "$path")
   provider="$2"
-  user="$3"
-  repo="$4"
+  user="$(convert_to_lower_case $3)"
+  repo="$(convert_to_lower_case $4)"
 
   if [ "$provider" = gitlab ] ; then
     # if the repo belongs to a group, repo will be in the format groupname/reponame
@@ -810,8 +815,8 @@ export_issues()
   test -n "$2" -a -n "$3" || usage_export
   test "$1" = github -o "$1" = gitlab || usage_export
   provider=$1
-  user="$2"
-  repo="$3"
+  user="$(convert_to_lower_case $2)"
+  repo="$(convert_to_lower_case $3)"
 
   cdissues
   test -d "imports/$provider/$user/$repo" || error "No local issues found for this repository."
@@ -886,8 +891,8 @@ sub_import()
   test "$1" = github -o "$1" = gitlab -a -n "$2" -a -n "$3" || usage_import
   provider="$1"
   # convert to lowercase to avoid duplicates
-  user="$(echo "$2" | tr '[:upper:]' '[:lower:]')"
-  repo="$(echo "$3" | tr '[:upper:]' '[:lower:]')"
+  user="$(convert_to_lower_case $2)"
+  repo="$(convert_to_lower_case $3)"
 
   cdissues
 
@@ -959,8 +964,8 @@ sub_exportall()
   test "$1" = github -o "$1" = gitlab || usage_exportall
   test -n "$2" -a -n "$3" || usage_exportall
   provider="$1"
-  user="$2"
-  repo="$3"
+  user="$(convert_to_lower_case $2)"
+  repo="$(convert_to_lower_case $3)"
 
   # Create list of relevant shas sorted by date
   shas=$(sub_list -l %i -o %c "$all"| sed '/^$/d' | tr '\n' ' ')


### PR DESCRIPTION
Fix #84: Ensure `import` and `export` find the same issue directory.

I have added lower casing to import/export functions that parse command line arguments. I _think_ I have caught all of them. Four considerations had come to mind:

1) The `create_issue` function is used internally in a `for` loop in two other functions. So this adds redundant lower casing in these loops. This is unlikely to be a bottleneck though.
2) I did not add a test case to `test.sh`. I can have a go at it, but it will take me a bit of time to understand the test script.
3) This commit is likely to clash with #82. The pull request in there may also need to consider letter cases?
4) I decided against lower casing `$provider`. All definitions of the variable from user input are preceded by an explicit comparison to `github` and `gitlab`, making the lower casing entirely redundant. Moving the comparison to after the lower casing is possible to allow, for example, `git issue import GitLab <...>`. Please let me know if that is desirable.