### PR TITLE
git issue list: only show open issues unless -a is passed

### DIFF
--- a/git-issue.sh
+++ b/git-issue.sh
@@ -1160,7 +1160,7 @@ sub_list()
   if [ "$all" ] ; then
     cat
   else
-    sed 's/\/milestone$/\/tags/' - | xargs grep -Flx open
+    sed 's/\/milestone$/\/tags/' | xargs grep -Flx open
   fi |
   # Convert list of tag or milestone file paths into the corresponding
   # directory and issue id

--- a/git-issue.sh
+++ b/git-issue.sh
@@ -1145,14 +1145,22 @@ sub_list()
   esac
   shift $((OPTIND - 1));
   tag="$1"
-  : "${tag:=open}"
+  if [ "$tag" = "closed" ] ; then
+    # when explicitly searching for closed tickets, don't show only open ones
+    all=1
+  fi
   cdissues
   test -d issues || exit 0
   find issues -type f -name tags -o -name milestone |
+  if [ "$tag" ] ; then
+    xargs grep -Flx "$tag"
+  else
+    cat
+  fi |
   if [ "$all" ] ; then
     cat
   else
-    xargs grep -Flx "$tag"
+    sed 's/\/milestone$/\/tags/' - | xargs grep -Flx open
   fi |
   # Convert list of tag or milestone file paths into the corresponding
   # directory and issue id


### PR DESCRIPTION
The README states
> * `git issue list`: List open issues (or all with `-a`).
>    An optional argument can show issues matching a tag or milestone.

My expectation in this case was that when searching for tag I would only get open issues with that tag (unless `-a` is provided). This pull request changes the working of `git issue list` to match that expectation, with the exception that when the tag that is searched for is "closed" `-a` is implied.