### PR TITLE
store issues as a private issues branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ You use _git issue_ with the following sub-commands.
 ### Start an issue repository
 * `git issue clone`: Clone the specified remote repository.
 * `git issue init`: Create a new issues repository in the current directory.
-  The `-e` option uses an existing Git project repository.
+  The `-e` option uses an existing Git project repository and store issues as a private issues branch.
+  The `-r` option stores the issues in a new issues repository.
 
 ### Work with an issue
 * `git issue new`: Create a new open issue (with optional `-s` summary and -c "provider user repo" for github/gitlab export).

--- a/git-issue.1
+++ b/git-issue.1
@@ -48,7 +48,8 @@ Clone the specified remote repository.
 \fBgit issue init\fP
 .RS 4
 Create a new issues repository in the current directory.
-The \fC-e\fP option uses an existing Git project repository.
+The \fC-e\fP option uses an existing Git project repository and store issues as a private issues branch.
+The \fC-r\fP option stores the issues in a new issues repository.
 
 .RE
 .PP


### PR DESCRIPTION
This pull request addresses issue #9 

In the existing Git repository, the default behaviour has been updated. Previously, the default behaviour was to store the issues in a new issues repository. However, the new default behaviour is to store the issues as a private issues branch within the existing git repository. The -r option can be used to store the issues in a new issues repository.

In cases where the existing Git repository is empty without any commits, it is not possible to create a private issues branch. To resolve this, a commit will be made with the addition of the .git-issues-init.txt file. This commit will appear in the project's Git log, indicating that git-issue is now initialized in the project.