### PR TITLE
Respect git --no-pager option by using GIT_PAGER variable

### DIFF
--- a/git-issue.1
+++ b/git-issue.1
@@ -261,8 +261,10 @@ that element and can be used to derive its date and author.
 .SH ENVIRONMENT
 The \fCVISUAL\fP environment variable is used for determining the user's
 editor.
-The \fCPAGER\fP environment variable is used for determining the program
-to use to display long lists of results.
+The \fCGIT_PAGER\fP environment variable (set by git when using --no-pager)
+takes precedence over \fCPAGER\fP for determining the program to use to
+display long lists of results.
+If \fCGIT_PAGER\fP is not set, the \fCPAGER\fP environment variable is used.
 
 .SH FILES
 .\" Auto-generated content from README.md; do not edit this section

--- a/git-issue.sh
+++ b/git-issue.sh
@@ -207,7 +207,7 @@ edit()
 # Pipe input through the user's pager
 pager()
 {
-  ${PAGER:-more}
+  ${GIT_PAGER:-${PAGER:-more}}
 }
 
 # init: Initialize a new issue repository {{{1


### PR DESCRIPTION
When git is invoked with --no-pager, it sets GIT_PAGER to 'cat'. This change makes git-issue respect that setting by checking GIT_PAGER before falling back to the PAGER environment variable or the default 'more' command.

Also updated the man page to document this behavior.

Test by invoking a command that uses pager such as `list`:
```shell
git --no-pager issue list
```